### PR TITLE
Fix build issue with automation toolFix build issue with automation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ be especially valuable:
 
 Please feel free to submit pull requests or open issues if you would like to contribute or report bugs.
 
+Currently, we lack of build checks in PRs, so please try to validate the plugin builds correctly before submitting a PR.
+Check [here](#build-with-automation-tool) to build using command line tools provided by UE5.
+
 ## Documentation
 
 All code is well-documented, and much of the documentation was inspired by Unity ML-Agents. Most methods, classes, and
@@ -73,3 +76,14 @@ general documentation to make it easier for developers to get started.
 For now, you can refer to Unity's excellent documentation here: [Unity ML-Agents Documentation](https://unity-technologies.github.io/ml-agents/ML-Agents-Overview/).
 
 More detailed Unreal-specific documentation is in progress.
+
+## Build with Automation Tool
+
+UE Automation Tool can be used to build the plugin, currently used for build checks when making changes.
+
+As an example on Windows, using `cmd`:
+```
+F:\UE_5.2\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin="<path to this repo>\UnrealMLAgents.uplugin" -package="<somewhere>" -TargetPlatforms=Win64
+```
+
+[source](https://dev.epicgames.com/community/learning/tutorials/qz93/unreal-engine-building-plugins)

--- a/Source/UnrealMLAgents/Private/Academy.cpp
+++ b/Source/UnrealMLAgents/Private/Academy.cpp
@@ -1,7 +1,13 @@
 #include "UnrealMLAgents/Academy.h"
-#include "Editor/EditorEngine.h"
-#include "Editor.h"
+
+#if WITH_EDITOR
+	#include "Editor/EditorEngine.h"
+	#include "Editor.h"
+#endif
+
 #include "GenericPlatform/GenericPlatformMisc.h"
+#include "Misc/CoreDelegates.h"
+#include "Misc/CommandLine.h"
 
 UAcademy* UAcademy::Instance = nullptr;
 

--- a/Source/UnrealMLAgents/Public/UnrealMLAgents/Communicator/ICommunicator.h
+++ b/Source/UnrealMLAgents/Public/UnrealMLAgents/Communicator/ICommunicator.h
@@ -24,23 +24,18 @@ struct FCommunicatorInitParameters
 	GENERATED_BODY()
 
 	/** @brief The port number used for communication. */
-	UPROPERTY(BlueprintReadWrite)
 	int32 Port;
 
 	/** @brief The name of the Unreal environment. */
-	UPROPERTY(BlueprintReadWrite)
 	FString Name;
 
 	/** @brief The version of the Unreal package. */
-	UPROPERTY(BlueprintReadWrite)
 	FString UnrealPackageVersion;
 
 	/** @brief The version of the Unreal communication protocol. */
-	UPROPERTY(BlueprintReadWrite)
 	FString UnrealCommunicationVersion;
 
 	/** @brief Capabilities of the C# codebase used in the RL framework. */
-	UPROPERTY(BlueprintReadWrite)
 	FString CSharpCapabilities;
 };
 
@@ -57,23 +52,18 @@ struct FUnrealRLInitParameters
 	GENERATED_BODY()
 
 	/** @brief The random number seed sent from the external trainer. */
-	UPROPERTY(BlueprintReadWrite)
 	int32 Seed;
 
 	/** @brief The number of areas in the Unreal environment. */
-	UPROPERTY(BlueprintReadWrite)
 	int32 NumAreas;
 
 	/** @brief The version of the Python library being used by the external trainer. */
-	UPROPERTY(BlueprintReadWrite)
 	FString PythonLibraryVersion;
 
 	/** @brief The version of the communication protocol used by Python. */
-	UPROPERTY(BlueprintReadWrite)
 	FString PythonCommunicationVersion;
 
 	/** @brief The capabilities of the trainer (external process). */
-	UPROPERTY(BlueprintReadWrite)
 	FString TrainerCapabilities;
 };
 
@@ -89,7 +79,6 @@ struct FUnrealRLInputParameters
 	GENERATED_BODY()
 
 	/** @brief Boolean flag indicating if training is enabled. */
-	UPROPERTY(BlueprintReadWrite)
 	bool bIsTraining;
 };
 

--- a/Source/UnrealMLAgents/Public/UnrealMLAgents/Communicator/RpcCommunicator.h
+++ b/Source/UnrealMLAgents/Public/UnrealMLAgents/Communicator/RpcCommunicator.h
@@ -11,6 +11,13 @@
 #include "ueagents_envs/communicator_objects/unreal_rl_output.pb.h"
 #include "ueagents_envs/communicator_objects/unreal_message.pb.h"
 #include "ueagents_envs/communicator_objects/unreal_rl_input.pb.h"
+
+// This should fix error C2039: 'GetObjectW': is not a member of 'TScriptInterface<IBlendableInterface>'
+// Issues seems to be related to an issue in the generated files.
+#ifdef GetObject
+	#undef GetObject
+#endif
+
 #include "RpcCommunicator.generated.h"
 
 /**

--- a/Source/UnrealMLAgents/Public/UnrealMLAgents/Grpc/CommunicatorObjects/AgentInfo.h
+++ b/Source/UnrealMLAgents/Public/UnrealMLAgents/Grpc/CommunicatorObjects/AgentInfo.h
@@ -17,35 +17,27 @@ struct UNREALMLAGENTS_API FAgentInfo
 	GENERATED_BODY()
 
 	/** @brief The current reward for the agent. */
-	UPROPERTY(BlueprintReadWrite)
 	float Reward;
 
 	/** @brief The current group reward received by the agent. */
-	UPROPERTY(BlueprintReadWrite)
 	float GroupReward;
 
 	/** @brief Whether the agent is done (i.e., whether it has completed its episode). */
-	UPROPERTY(BlueprintReadWrite)
 	bool bDone;
 
 	/** @brief Whether the agent has reached its maximum step count for the current episode. */
-	UPROPERTY(BlueprintReadWrite)
 	bool bMaxStepReached;
 
 	/** @brief The episode identifier assigned to the agent at each reset. */
-	UPROPERTY(BlueprintReadWrite)
 	int32 EpisodeId;
 
 	/** @brief The MultiAgentGroup identifier for the agent. */
-	UPROPERTY(BlueprintReadWrite)
 	int32 GroupId;
 
 	/** @brief The action buffers containing the most recent actions taken by the agent. */
-	UPROPERTY(BlueprintReadWrite)
 	FActionBuffers StoredActions;
 
 	/** @brief For discrete control, specifies the actions that the agent cannot take. */
-	UPROPERTY(BlueprintReadWrite)
 	TArray<bool> DiscreteActionMasks;
 
 	/**

--- a/Source/UnrealMLAgents/UnrealMLAgents.Build.cs
+++ b/Source/UnrealMLAgents/UnrealMLAgents.Build.cs
@@ -6,16 +6,20 @@ using System.Reflection;
 
 public class UnrealMLAgents : ModuleRules
 {
-	private static CommunicatorPlatform CommunicatorPlatformInstance;
+	private static MLAgentsPlatform MLAgentsPlatformInstance;
 
 	public UnrealMLAgents(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		CommunicatorPlatformInstance = GetCommunicatorPlatformInstance(Target);
+		MLAgentsPlatformInstance = GetMLAgentsPlatformInstance(Target);
 		bEnableExceptions = true;
 
-		PrivateDependencyModuleNames.AddRange(
-			new string[] { "Slate", "SlateCore", "Core", "CoreUObject", "Engine", "UnrealEd" });
+		PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore", "Core", "CoreUObject", "Engine" });
+
+		if (Target.bBuildEditor)
+		{
+			PrivateDependencyModuleNames.AddRange(new string[] { "UnrealEd" });
+		}
 
 		AddEngineThirdPartyPrivateStaticDependencies(Target, "OpenSSL");
 		AddEngineThirdPartyPrivateStaticDependencies(Target, "zlib");
@@ -31,17 +35,20 @@ public class UnrealMLAgents : ModuleRules
 
 		// ThirdParty Libraries
 		ConfigurePlatform(Target.Platform.ToString(), Target.Configuration);
+
+		PublicDefinitions.Add("WIN32_LEAN_AND_MEAN");
+		PublicDefinitions.Add("NOMINMAX");
 	}
 
-	private CommunicatorPlatform GetCommunicatorPlatformInstance(ReadOnlyTargetRules Target)
+	private MLAgentsPlatform GetMLAgentsPlatformInstance(ReadOnlyTargetRules Target)
 	{
-		var CommunicatorPlatformType = System.Type.GetType("CommunicatorPlatform_" + Target.Platform.ToString());
-		if (CommunicatorPlatformType == null)
+		var MLAgentsPlatformType = System.Type.GetType("MLAgentsPlatform_" + Target.Platform.ToString());
+		if (MLAgentsPlatformType == null)
 		{
 			throw new BuildException("UnrealMLAgents does not support platform " + Target.Platform.ToString());
 		}
 
-		var PlatformInstance = Activator.CreateInstance(CommunicatorPlatformType) as CommunicatorPlatform;
+		var PlatformInstance = Activator.CreateInstance(MLAgentsPlatformType) as MLAgentsPlatform;
 		if (PlatformInstance == null)
 		{
 			throw new BuildException("UnrealMLAgents could not instantiate platform " + Target.Platform.ToString());
@@ -82,53 +89,50 @@ public class UnrealMLAgents : ModuleRules
 		// grpc
 		foreach (var lib in GrpcLibs)
 		{
-			foreach (var arch in CommunicatorPlatformInstance.Architectures())
+			foreach (var arch in MLAgentsPlatformInstance.Architectures())
 			{
-				string fullPath = root + "grpc/" + "lib/" + CommunicatorPlatformInstance.LibrariesPath + arch
-					+ CommunicatorPlatformInstance.ConfigurationDir(Configuration)
-					+ CommunicatorPlatformInstance.LibraryPrefixName + lib
-					+ CommunicatorPlatformInstance.LibraryPostfixName;
+				string fullPath = root + "grpc/" + "lib/" + MLAgentsPlatformInstance.LibrariesPath + arch
+					+ MLAgentsPlatformInstance.ConfigurationDir(Configuration)
+					+ MLAgentsPlatformInstance.LibraryPrefixName + lib + MLAgentsPlatformInstance.LibraryPostfixName;
 				PublicAdditionalLibraries.Add(fullPath);
 			}
 		}
 		// protobuf
 		foreach (var lib in ProtobufLibs)
 		{
-			foreach (var arch in CommunicatorPlatformInstance.Architectures())
+			foreach (var arch in MLAgentsPlatformInstance.Architectures())
 			{
-				string libPrefixName = CommunicatorPlatformInstance.LibraryPrefixName;
-				if (CommunicatorPlatformInstance is CommunicatorPlatform_Win64 && lib == "protobuf")
+				string libPrefixName = MLAgentsPlatformInstance.LibraryPrefixName;
+				if (MLAgentsPlatformInstance is MLAgentsPlatform_Win64 && lib == "protobuf")
 				{
 					libPrefixName = "lib"; //'libprotobuf.lib'
 				}
 
-				string fullPath = root + "protobuf/" + "lib/" + CommunicatorPlatformInstance.LibrariesPath + arch
-					+ CommunicatorPlatformInstance.ConfigurationDir(Configuration) + libPrefixName + lib
-					+ CommunicatorPlatformInstance.LibraryPostfixName;
+				string fullPath = root + "protobuf/" + "lib/" + MLAgentsPlatformInstance.LibrariesPath + arch
+					+ MLAgentsPlatformInstance.ConfigurationDir(Configuration) + libPrefixName + lib
+					+ MLAgentsPlatformInstance.LibraryPostfixName;
 				PublicAdditionalLibraries.Add(fullPath);
 			}
 		}
 		// abseil
 		foreach (var lib in AbseilLibs)
 		{
-			foreach (var arch in CommunicatorPlatformInstance.Architectures())
+			foreach (var arch in MLAgentsPlatformInstance.Architectures())
 			{
-				string fullPath = root + "abseil/" + "lib/" + CommunicatorPlatformInstance.LibrariesPath + arch
-					+ CommunicatorPlatformInstance.ConfigurationDir(Configuration)
-					+ CommunicatorPlatformInstance.LibraryPrefixName + lib
-					+ CommunicatorPlatformInstance.LibraryPostfixName;
+				string fullPath = root + "abseil/" + "lib/" + MLAgentsPlatformInstance.LibrariesPath + arch
+					+ MLAgentsPlatformInstance.ConfigurationDir(Configuration)
+					+ MLAgentsPlatformInstance.LibraryPrefixName + lib + MLAgentsPlatformInstance.LibraryPostfixName;
 				PublicAdditionalLibraries.Add(fullPath);
 			}
 		}
 		// re2
 		foreach (var lib in Re2Libs)
 		{
-			foreach (var arch in CommunicatorPlatformInstance.Architectures())
+			foreach (var arch in MLAgentsPlatformInstance.Architectures())
 			{
-				string fullPath = root + "re2/" + "lib/" + CommunicatorPlatformInstance.LibrariesPath + arch
-					+ CommunicatorPlatformInstance.ConfigurationDir(Configuration)
-					+ CommunicatorPlatformInstance.LibraryPrefixName + lib
-					+ CommunicatorPlatformInstance.LibraryPostfixName;
+				string fullPath = root + "re2/" + "lib/" + MLAgentsPlatformInstance.LibrariesPath + arch
+					+ MLAgentsPlatformInstance.ConfigurationDir(Configuration)
+					+ MLAgentsPlatformInstance.LibraryPrefixName + lib + MLAgentsPlatformInstance.LibraryPostfixName;
 				PublicAdditionalLibraries.Add(fullPath);
 			}
 		}
@@ -136,7 +140,7 @@ public class UnrealMLAgents : ModuleRules
 	}
 }
 
-public abstract class CommunicatorPlatform
+public abstract class MLAgentsPlatform
 {
 	public virtual string ConfigurationDir(UnrealTargetConfiguration Configuration)
 	{
@@ -155,7 +159,7 @@ public abstract class CommunicatorPlatform
 	public abstract string		 LibraryPostfixName { get; }
 }
 
-public class CommunicatorPlatform_Win64 : CommunicatorPlatform
+public class MLAgentsPlatform_Win64 : MLAgentsPlatform
 {
 	public override string ConfigurationDir(UnrealTargetConfiguration Configuration)
 	{
@@ -189,7 +193,7 @@ public class CommunicatorPlatform_Win64 : CommunicatorPlatform
 	}
 }
 
-public class CommunicatorPlatform_Linux : CommunicatorPlatform
+public class MLAgentsPlatform_Linux : MLAgentsPlatform
 {
 	public override string LibrariesPath
 	{
@@ -212,7 +216,7 @@ public class CommunicatorPlatform_Linux : CommunicatorPlatform
 	}
 }
 
-public class CommunicatorPlatform_Mac : CommunicatorPlatform
+public class MLAgentsPlatform_Mac : MLAgentsPlatform
 {
 	public override string ConfigurationDir(UnrealTargetConfiguration Configuration) { return ""; }
 	public override		   string LibrariesPath


### PR DESCRIPTION
Set the module type to `Editor` as currently it runs only in the Editor. An improvement would be to try to split the plugin in different modules so we can split Runtime and Editor types of modules.

Add `Category` to `UPROPERTIES`

Make some includes explicit, for better control over dependencies.

Update the README to give some guidelines to build the plugin as standalone for development and build checks.